### PR TITLE
Pricelist for Data Science isn't accessible

### DIFF
--- a/project/softeng2/toc.yml
+++ b/project/softeng2/toc.yml
@@ -81,7 +81,7 @@
     - name: "💡 WEB API #2"
       href: ./9b_gyak_crude_viccek/index.md
     - name: "💡 Project Description & Price List"
-      href: ./ds_week11_cherry_p
+      href: ./ds_week11_cherry_picking/pricelist.md
 - name: Week 12 Project presentationsicking/pricelist.md
   items:
 


### PR DESCRIPTION
This change fixes the 404 error when navigating from the TOC to the pricelist in the Data Science page.